### PR TITLE
Simplify package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,16 @@ https://github.com/aurb/vonsh/
 
 ## Depedencies
 Package dependencies:
-+ libc6 (>= 2.2.5)
-+ libsdl2-2.0-0 (>= 2.0.9)
-+ libsdl2-image-2.0-0 (>= 2.0.2)
-+ libsdl2-mixer-2.0-0 (>= 2.0.2)
++ SDL 2
++ SDL\_image 2
++ SDL\_mixer 2
 
 Build dependencies:
-+ libc6-dev (>=2.28)
-+ gcc (>=4:8.3.0)
-+ g++ (>=4:8.3.0)
-+ make (>=4.2.1)
-+ dpkg-dev (>=1.19.7)
-+ debhelper (>= 12)
-+ libsdl2-dev (>=2.0.9)
-+ libsdl2-image-dev (>=2.0.4)
-+ libsdl2-mixer-dev (>=2.0.4)
++ build-essential
++ debhelper (>= 9)
++ libsdl2-dev
++ libsdl2-image-dev
++ libsdl2-mixer-dev
 
 ## How to build and install
 Commands to be executed from project root directory:

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vonsh
 Section: games
 Priority: optional
 Maintainer: Andrzej Urbaniak <au742582@interia.pl>
-Build-Depends: libc6-dev (>=2.28), gcc (>=4:8.3.0), g++ (>=4:8.3.0), make (>=4.2.1), dpkg-dev (>=1.19.7), debhelper (>= 12), libsdl2-dev (>=2.0.9), libsdl2-image-dev (>=2.0.4), libsdl2-mixer-dev (>=2.0.4)
+Build-Depends: debhelper (>= 9), libsdl2-dev, libsdl2-image-dev, libsdl2-mixer-dev
 Standards-Version: 4.3.0
 Homepage: https://github.com/aurb/vonsh/
 


### PR DESCRIPTION
Currently, both the `README` and the `Build-Depends` of the Debian package require versions of libraries as available in Debian Buster; however, vonsh does not really require them, i.e. it builds fine in Debian Stretch too. Also, some of the packages required for the Debian build are part of the base `build-essential` set, and thus no need to be specified (unless a specific version is required, which is not the case).

Hence, simplify the list of requirements:
- do not mention `libc6` as requirement: it is the C library, always available
- mention the 3 SDL modules by name, not by Debian package name
- remove `libc6-dev`, `gcc`, `g++`, `make`, and `dpkg-dev` from the build dependencies: any version of them works just fine, and they are part of `build-essential`
- mention `build-essential` only in the `README`, so users know what to install
- lower the version of `debhelper` to 9, as it is the compat level requested by `debian/compat`
- drop the version of `libsdl2-dev`, `libsdl2-image-dev`, and `libsdl2-mixer-dev`, as older versions work just fine